### PR TITLE
Watson STT Patch

### DIFF
--- a/docs/demo/app.js
+++ b/docs/demo/app.js
@@ -2232,6 +2232,7 @@ module.exports = Backbone.View.extend({
     var ibmCredentials = {};
     ibmCredentials.username = this.$('input[name=username-ibm]').val().trim();
     ibmCredentials.password = this.$('input[name=password-ibm]').val().trim();
+    ibmCredentials.url = this.$('input[name=url-ibm]').val().trim();
     //TODO: double check this
     if (ibmCredentials.username != "" && ibmCredentials.password != "") {
       //save 

--- a/docs/demo/watson_keys.js
+++ b/docs/demo/watson_keys.js
@@ -13,7 +13,7 @@ if (window.process !== 'undefined') {
   var watsonKeysPath = "";
 }
 
-var watsonKeys = {username: "", password: ""};
+var watsonKeys = {username: "", password: "", url : ""};
 // var watsonKeysSet = false;
 
 // load keys on startup
@@ -45,6 +45,7 @@ function getWatsonAPIkeys(){
 
 //set
 function setWatsonAPIkeys(keys){
+  console.log(`SAVING KEYS TO ${watsonKeysPath}`);
   if(keysAreValid(keys)){
      fs.writeFileSync(watsonKeysPath, JSON.stringify(keys));
     }else{

--- a/lib/app/templates/settings_template.html.ejs
+++ b/lib/app/templates/settings_template.html.ejs
@@ -54,6 +54,10 @@
 					<label for="password">IBM STT Password</label>
 					<input type="title" name="password-ibm" value="<%= credentials.ibm.password  %>" class="form-control" id="password" placeholder="e.g. 2QKJ79uRsD2a">
 				</div>
+				<div class="form-group">
+					<label for="url">IBM Instance URL</label>
+					<input type="title" name="url-ibm" value="<%= credentials.ibm.url  %>" class="form-control" id="url" placeholder="https://gateway-syd.watsonplatform.net/speech-to-text/api">
+				</div>
 				<a id="submitBtnIbmCredentials" class="btn btn-primary">Save Credentials</a>
 			</div><!-- ./col -->
 		</div><!-- ./row -->

--- a/lib/app/views/settings_view.js
+++ b/lib/app/views/settings_view.js
@@ -39,6 +39,7 @@ module.exports = Backbone.View.extend({
     var ibmCredentials = {};
     ibmCredentials.username  = this.$('input[name=username-ibm]').val().trim();
     ibmCredentials.password  = this.$('input[name=password-ibm]').val().trim();
+    ibmCredentials.url  = this.$('input[name=url-ibm]').val().trim();
    //TODO: double check this
     if((ibmCredentials.username  != "") && (ibmCredentials.password != "")){
       //save 

--- a/lib/interactive_transcription_generator/index.js
+++ b/lib/interactive_transcription_generator/index.js
@@ -115,7 +115,9 @@ var generate = function(config) {
   var timeStamp         = Date.now();
   var audioFileName     = path.join(config.destFolder, videoFileName +"."+timeStamp+ ".ogg");
   var oggOutputNamePath = path.join(config.destFolder, videoFileName +"."+timeStamp+ ".webm");
- 
+  
+  console.log('Transcription Config:', config);
+
   //transcribing file 
   transcribe({
     videoFile: config.videoUrl,

--- a/lib/interactive_transcription_generator/transcriber/ibm_stt_node/send_to_watson.js
+++ b/lib/interactive_transcription_generator/transcriber/ibm_stt_node/send_to_watson.js
@@ -25,7 +25,7 @@
 "use strict";
 
 var fs = require("fs");
-var watson = require('watson-developer-cloud');
+var SpeechToTextV1 = require('watson-developer-cloud/speech-to-text/v1');
 
 //  Initialise var so that scope allows to set api keys
 //TODO: not sure if this i needed
@@ -68,11 +68,20 @@ ko-KR_NarrowbandModel
 SendToWatson.prototype.send = function(audioFile,keys, languageModel, cb){
 
   //credentials for STT API 
-  speech_to_text = watson.speech_to_text({
+
+  const stt_config = {
     username: keys.username,
-    password: keys.password,
-    version: 'v1'
-  });
+    password : keys.password
+  };
+
+  // If the username is 'apikey', we're using a newer Watson STT instance, so we'll add the iam_apikey property and set an instance
+  // endpoint URL if there is one.
+  if(keys.username === 'apikey'){
+    stt_config.iam_apikey = keys.password;
+    stt_config.url = keys.url;
+  }
+
+  var speech_to_text = new SpeechToTextV1( stt_config );
 
   //params to send to IBM STT API request
   var params = {

--- a/project_page/demo/app.js
+++ b/project_page/demo/app.js
@@ -2232,6 +2232,7 @@ module.exports = Backbone.View.extend({
     var ibmCredentials = {};
     ibmCredentials.username = this.$('input[name=username-ibm]').val().trim();
     ibmCredentials.password = this.$('input[name=password-ibm]').val().trim();
+    ibmCredentials.url = this.$('input[name=url-ibm]').val().trim();
     //TODO: double check this
     if (ibmCredentials.username != "" && ibmCredentials.password != "") {
       //save 


### PR DESCRIPTION
Temporary fix to enable users of newer Watson STT credentials to continue using autoEdit until such a time that the copy / setup steps can be updated.

Suffice it to say:

Instead of using a `username`/`password` combination use:

`apikey` as the username 
`<YOUR_API_KEY_FROM_YOUR_RECENT_STT_INSTACE>` instead of password.

You will also need to include the `url` value from the credentials object (where you get your API key from) along with the above.

Addresses #49 