### PR TITLE
ffmpeg remix

### DIFF
--- a/electron/db.js
+++ b/electron/db.js
@@ -196,7 +196,9 @@ DB.create = function(model, success, error) {
           });
         },
         cbVideo: function(respV) {
-          console.log('cbVideo: ', respV);
+          if(err){
+            console.log('cbVideo: ', respV);
+          }
           // updating current transcription with webm html5 video preview.
           Transcription.findOne({ _id: transcription._id }, function (err, trs) {
             if (err) {

--- a/electron/index.html
+++ b/electron/index.html
@@ -149,7 +149,9 @@
 
   <script>
   if (window.process !== undefined) {
-  var ffmpegExentions = require("./ffmpeg_extentions.js")
+    const path = require('path');
+    const remix = require('ffmpeg-remix');
+    const ffmpegExentions = require("./ffmpeg_extentions.js")
    // file dialogue opener 
    const {dialog} = require('electron').remote;
 
@@ -178,6 +180,37 @@
         if(cb){cb(fileName)};
       });
      }
+
+      window.ffmpegRemix = function (jsonSequence, cb){
+      // https://github.com/electron/electron/blob/master/docs/api/dialog.md#dialogshowsavedialogbrowserwindow-options-callback
+      var savePath = dialog.showSaveDialog({});
+      console.log('savePath',savePath);
+      console.log('jsonSequence.output',jsonSequence.output);
+      // if user does not specify mp4 extension then we should add it othersiwe ffmpeg will fail
+      if(!isVideoFileMp4(savePath)){
+        savePath +='.mp4';
+      }
+      jsonSequence.output = savePath;
+      console.log('jsonSequence.output',jsonSequence.output);
+      // jsonSequence.ffmpegPath = require('ffmpeg-static').path; 
+      jsonSequence.ffmpegPath =  require("../config.js").ffmpegPath;
+      // //call ffmpeg remix
+      
+      remix(jsonSequence,function(err, result) {
+        console.log(err, result);
+          if(cb){cb(savePath)}
+      })
+     }
+      function isVideoFileMp4(file){
+      var extname = path.extname(file);
+      if(extname === '.mp4'){
+        return true;
+      }
+      else{
+        return false;
+      }
+    }
+
 
   }
 </script>

--- a/lib/app/models/transcription.js
+++ b/lib/app/models/transcription.js
@@ -274,8 +274,8 @@ module.exports = Backbone.Model.extend({
     return result;
   },
 
-  returnEDLSrtJson: function(text) {
-    return createSrtContent(text);
-  }
+  // returnEDLSrtJson: function(text) {
+  //   return createSrtContent(text);
+  // }
 
 });

--- a/lib/app/templates/paperedit_show.html.ejs
+++ b/lib/app/templates/paperedit_show.html.ejs
@@ -119,14 +119,19 @@ height: 20vh;
         <div class="modal-body">
           <!-- Export options -->
           <h2><small>Video sequence </small></h2>
-          <p>You can export an EDL (edit decision list) to open a video sequence of the paperedit in the video editing software of choice.   <!-- See the user manual for more on this 
+          <p>You can export an EDL (edit decision list) to open a video sequence of the paperedit in the video editing software of choice. </p>  <!-- See the user manual for more on this 
             <a id="edlUserManualInfo" <span  class="glyphicon glyphicon-question-sign" aria-hidden="true"></span></a>.-->
             <!-- Btn Edl - chronological order | -->
 
             <p><a id="exportEdl" class="btn btn-primary btn-sm">
               <span class="glyphicon glyphicon-list-alt" aria-hidden="true"></span>
               EDL 
-            </a>
+            </a></p>
+            <p>You can export a video sequence of the paperedit as video file<code>.mp4</code></p>  
+           <p><a id="exportVideoRemix" class="btn btn-primary btn-sm">
+             <span class="glyphicon glyphicon-list-alt" aria-hidden="true"></span>
+             Export Video Sequence - mp4 
+           </a></p>
 
             <hr>
             <h2><small>Developer’s options </small> </h2>

--- a/lib/app/views/paperedit_view.js
+++ b/lib/app/views/paperedit_view.js
@@ -68,6 +68,7 @@ module.exports = Backbone.View.extend({
     'click .deletePapercut' : "deleteAllPapercuts",
     "click #exportEdlJSON"  : "exportEdlJSON",
     "click #exportEdl"      : "exportEdl",
+    "click #exportVideoRemix"      : "exportVideoRemix",
     "click .savePapercutsBtn": "savePapercuts",
     "click .playPapercutsBtn": "playPapercuts",
     "click .stopPapercutsBtn": "stopPapercuts",
@@ -280,6 +281,34 @@ exportEdlJSON: function(){
   var jsonFileName = this.nameFileHelper(papereditJson.title+"_EDL","json");  
   this.exportHelper({fileName: jsonFileName,fileContent: tmpPaperedit, urlId: "#exportJsonEDL"});
 },
+
+  exportVideoRemix: function(){
+    var eventsPapercuts = this.model.attributes.events;
+    var m4RemixFileName = this.nameFileHelper(this.model.attributes.title,"mp4"); 
+    var ffmpegRemixJson = this.autoEditEventPaperCutsJsonToFfmpegRemixJson(eventsPapercuts,m4RemixFileName);
+    window.ffmpegRemix(ffmpegRemixJson,(res)=>{
+      console.log(res)
+    alert('done exporting paper-edit mp4 video preview at: '+res);
+    })
+    console.log('exportVideoRemix');
+  },
+  autoEditEventPaperCutsJsonToFfmpegRemixJson(autoEditEventPapercutJson, fileName){
+    var ffmpegRemixInputArray =  autoEditEventPapercutJson.map((event)=>{
+    return { 
+        source: event.papercut[0].src,
+        start :parseFloat(event.papercut[0].startTime),
+        end: parseFloat(event.papercut[event.papercut.length-1].endTime)
+      }
+    })
+    return {
+    // TODO: edit this using electrong user file path
+    // or prompt dialogue to get user input on where to save.
+      output: fileName,
+      input: ffmpegRemixInputArray,
+      limit: 5 // max ffmpeg parallel processes, default null (unlimited)
+      // ffmpegPath: require('ffmpeg-static').path // optionally set path to ffmpeg binary
+    }
+  },
 
   //TODO: both make file helper and exportHelper should be moved in shared util and refactored out of transcription view as well
   /**

--- a/lib/interactive_transcription_generator/index.js
+++ b/lib/interactive_transcription_generator/index.js
@@ -250,14 +250,14 @@ var generate = function(config) {
   // }
 };
 
-function isVideoFileMp4(file){
-  var extname = path.extname(file);
-  if(extname === '.mp4'){
-    return true;
-  }
-  else{
-    return false;
-  }
-}
+// function isVideoFileMp4(file){
+//   var extname = path.extname(file);
+//   if(extname === '.mp4'){
+//     return true;
+//   }
+//   else{
+//     return false;
+//   }
+// }
 
 module.exports = generate;

--- a/package-lock.json
+++ b/package-lock.json
@@ -3262,19 +3262,21 @@
         "pend": "1.2.0"
       }
     },
-    "ffmpeg-static-electron": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ffmpeg-static-electron/-/ffmpeg-static-electron-2.0.0.tgz",
-      "integrity": "sha512-u8S790FaMFTmxPAD7wdR2xbnHVRqW8SLrxLjK3YSg7cTMKOIUCXZlxQXTYI0ywuFUoWTcnGvDlBYJ01Vu9iB+Q=="
+    "ffmpeg-remix": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/ffmpeg-remix/-/ffmpeg-remix-0.1.0.tgz",
+      "integrity": "sha512-hhcB5u2xS3mnKVW21pZJzWjpn1h0IjLNov5RU40aXDkL2GEQTitoGdZgDZzq8O3n+yZfv8U//ecJlr9szV2dZA==",
+      "requires": {
+        "async": "2.6.0",
+        "debug": "2.6.9",
+        "fluent-ffmpeg": "2.1.0",
+        "tmp": "0.0.28"
+      }
     },
     "ffmpeg-static-electron": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ffmpeg-static-electron/-/ffmpeg-static-electron-2.0.1.tgz",
       "integrity": "sha512-tLOZJu2PJbDT7oMPhaAmmTZEZZms9R9D2FyhqsBrGlVhfqMi/ipuwNdogwk0+QEnDKaPhXwIgdnkd5Gn5tDXjw=="
-    },
-    "ffprobe-static": {
-      "version": "git+https://github.com/pietrop/ffprobe-static.git#cf75a358c695bd58c94823efb06dab258d019ccb",
-      "from": "git+https://github.com/pietrop/ffprobe-static.git"
     },
     "ffprobe-static-electron": {
       "version": "2.0.0",
@@ -8230,8 +8232,7 @@
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-      "dev": true
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "outpipe": {
       "version": "1.1.1",
@@ -10927,7 +10928,6 @@
       "version": "0.0.28",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.28.tgz",
       "integrity": "sha1-Fyc1t/YU6nrzlmT6hM8N5OUV0SA=",
-      "dev": true,
       "requires": {
         "os-tmpdir": "1.0.2"
       }

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "backbone": "^1.3.3",
     "bootstrap": "^3.3.7",
     "electron-debug": "^1.1.0",
+    "ffmpeg-remix": "^0.1.0",
     "ffmpeg-static-electron": "^2.0.1",
     "ffprobe-static-electron": "^2.0.0",
     "file-saver": "^1.3.3",


### PR DESCRIPTION
Fast video sequence export as `mp4` video of paper-edit using [`ffmpeg-remix`](https://github.com/Laurian/ffmpeg-remix) module

- [x]  after mp4 branch PR
- [x] Move ffmpeg-remix to node dependencies 
- [x] move ffmpeg and ffprobe static electron modules to dependencies
- [ ] Add check if file extension of `videoOgg` for each paper-cut is `.webm` as that breaks the ffmpeg-remix module, as it only works if the files are all `mp4`
- [x] implemented and manually tested ffmpegremix






