### PR TITLE
changed form labels to 'API Key' from 'Password' in settings

### DIFF
--- a/lib/app/templates/settings_template.html.ejs
+++ b/lib/app/templates/settings_template.html.ejs
@@ -49,7 +49,7 @@
 					<input type="text" name="username-ibm" value="<%= credentials.ibm.username %>" class="form-control" id="username" placeholder="e.g. PMYs8ZexZ7qKGkFgFJhGMYhqzEC4aNzRAv9H">
 				</div>
 				<div class="form-group">
-					<label for="password">IBM STT Password</label>
+					<label for="password">IBM STT API Key</label>
 					<input type="text" name="password-ibm" value="<%= credentials.ibm.password  %>" class="form-control" id="password" placeholder="e.g. 2QKJ79uRsD2a">
 				</div>
 				<div class="form-group">
@@ -85,7 +85,7 @@
 						<input type="text" name="username-speechmatics" value="<%= credentials.speechmatics.username %>" class="form-control" id="username" placeholder="e.g. 72249">
 					</div>
 					<div class="form-group">
-						<label for="password">Speechmatics STT Password</label>
+						<label for="password">Speechmatics STT API Key</label>
 						<input type="text" name="password-speechmatics" value="<%= credentials.speechmatics.password  %>" class="form-control" id="password" placeholder="e.g. dYsaEPJZGzjdAEfW3R4oRXDaMkPwb9aqxDMwwMrekRAAnDxP">
 					</div>
 				<a id="submitBtnSpeechmaticsCredentials" class="btn btn-primary">Save Speechmatics Credentials</a>


### PR DESCRIPTION
For Speechmatics and Watson.

"Password" is confusing, and you don't want to unnecessarily send people to the docs just to realize what's needed is an API key, not a password.